### PR TITLE
feat(DropdownV2): support title and helper text options

### DIFF
--- a/src/components/DropdownV2/DropdownV2-story.js
+++ b/src/components/DropdownV2/DropdownV2-story.js
@@ -44,6 +44,8 @@ const props = () => ({
   ariaLabel: text('Aria Label (ariaLabel)', 'Dropdown'),
   disabled: boolean('Disabled (disabled)', false),
   light: boolean('Light variant (light)', false),
+  titleText: text('Title (titleText)', 'This is not a dropdown title.'),
+  helperText: text('Helper text (helperText)', 'This is not some helper text.'),
 });
 
 const itemToElement = item => {

--- a/src/components/DropdownV2/DropdownV2-test.js
+++ b/src/components/DropdownV2/DropdownV2-test.js
@@ -55,6 +55,61 @@ describe('DropdownV2', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  describe('title', () => {
+    const wrapper = mount(
+      <DropdownV2 titleText="Email Input" {...mockProps} />
+    );
+    const renderedLabel = wrapper.find('label');
+
+    it('renders a title', () => {
+      expect(renderedLabel.length).toBe(1);
+    });
+
+    it('has the expected classes', () => {
+      expect(renderedLabel.hasClass('bx--label')).toEqual(true);
+    });
+
+    it('should set title as expected', () => {
+      expect(renderedLabel.text()).toEqual('Email Input');
+    });
+  });
+
+  describe('helper', () => {
+    it('renders a helper', () => {
+      const wrapper = mount(
+        <DropdownV2 helperText="Email Input" {...mockProps} />
+      );
+      const renderedHelper = wrapper.find('.bx--form__helper-text');
+      expect(renderedHelper.length).toEqual(1);
+    });
+
+    it('renders children as expected', () => {
+      const wrapper = mount(
+        <DropdownV2
+          helperText={
+            <span>
+              This helper text has <a href="/">a link</a>.
+            </span>
+          }
+          {...mockProps}
+        />
+      );
+      const renderedHelper = wrapper.find('.bx--form__helper-text');
+      expect(renderedHelper.props().children).toEqual(
+        <span>
+          This helper text has <a href="/">a link</a>.
+        </span>
+      );
+    });
+
+    it('should set helper text as expected', () => {
+      const wrapper = mount(<DropdownV2 {...mockProps} />);
+      wrapper.setProps({ helperText: 'Helper text' });
+      const renderedHelper = wrapper.find('.bx--form__helper-text');
+      expect(renderedHelper.text()).toEqual('Helper text');
+    });
+  });
+
   it('should render DropdownItem components', () => {
     const wrapper = mount(<DropdownV2 {...mockProps} />);
     wrapper.setProps({

--- a/src/components/DropdownV2/DropdownV2.js
+++ b/src/components/DropdownV2/DropdownV2.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
 import ListBox, { PropTypes as ListBoxPropTypes } from '../ListBox';
+import FormItem from '../FormItem';
 
 const { prefix } = settings;
 
@@ -81,6 +82,18 @@ export default class DropdownV2 extends React.Component {
      * `true` to use the light version.
      */
     light: PropTypes.bool,
+
+    /**
+     * Provide the title text that will be read by a screen reader when
+     * visiting this control
+     */
+    titleText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+
+    /**
+     * Provide helper text that is used alongside the control label for
+     * additional help
+     */
+    helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   };
 
   static defaultProps = {
@@ -89,6 +102,8 @@ export default class DropdownV2 extends React.Component {
     itemToString: defaultItemToString,
     itemToElement: null,
     light: false,
+    titleText: '',
+    helperText: '',
   };
 
   handleOnChange = selectedItem => {
@@ -111,13 +126,24 @@ export default class DropdownV2 extends React.Component {
       selectedItem,
       light,
       id,
+      titleText,
+      helperText,
     } = this.props;
     const className = cx(`${prefix}--dropdown`, containerClassName, {
       [`${prefix}--dropdown--light`]: light,
     });
+    const title = titleText ? (
+      <label htmlFor={id} className={`${prefix}--label`}>
+        {titleText}
+      </label>
+    ) : null;
+    const helper = helperText ? (
+      <div className={`${prefix}--form__helper-text`}>{helperText}</div>
+    ) : null;
+
     // needs to be Capitalized for react to render it correctly
     const ItemToElement = itemToElement;
-    return (
+    const Dropdown = (
       <Downshift
         id={id}
         onChange={this.handleOnChange}
@@ -168,6 +194,15 @@ export default class DropdownV2 extends React.Component {
           </ListBox>
         )}
       </Downshift>
+    );
+    return title || helper ? (
+      <FormItem>
+        {title}
+        {helper}
+        {Dropdown}
+      </FormItem>
+    ) : (
+      Dropdown
     );
   }
 }

--- a/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
+++ b/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
@@ -3,6 +3,7 @@
 exports[`DropdownV2 should render 1`] = `
 <DropdownV2
   disabled={false}
+  helperText=""
   itemToElement={null}
   itemToString={[Function]}
   items={
@@ -38,6 +39,7 @@ exports[`DropdownV2 should render 1`] = `
   light={false}
   onChange={[MockFunction]}
   placeholder="Filter..."
+  titleText=""
   type="default"
 >
   <Downshift
@@ -101,7 +103,7 @@ exports[`DropdownV2 should render 1`] = `
           >
             <span
               className="bx--list-box__label"
-              htmlFor="downshift-0-input"
+              htmlFor="downshift-1-input"
             >
               input
             </span>
@@ -172,6 +174,7 @@ exports[`DropdownV2 should render 1`] = `
 exports[`DropdownV2 should render DropdownItem components 1`] = `
 <DropdownV2
   disabled={false}
+  helperText=""
   itemToElement={[Function]}
   itemToString={[Function]}
   items={
@@ -207,6 +210,419 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
   light={false}
   onChange={[MockFunction]}
   placeholder="Filter..."
+  titleText=""
+  type="default"
+>
+  <Downshift
+    breakingChanges={Object {}}
+    defaultHighlightedIndex={null}
+    defaultInputValue=""
+    defaultIsOpen={false}
+    defaultSelectedItem={null}
+    environment={[Window]}
+    getA11yStatusMessage={[Function]}
+    itemToString={[Function]}
+    onChange={[Function]}
+    onInputValueChange={[Function]}
+    onOuterClick={[Function]}
+    onSelect={[Function]}
+    onStateChange={[Function]}
+    onUserAction={[Function]}
+    selectedItemChanged={[Function]}
+    stateReducer={[Function]}
+  >
+    <ListBox
+      ariaLabel="Choose an item"
+      className="bx--dropdown"
+      disabled={false}
+      innerRef={[Function]}
+      type="default"
+    >
+      <div
+        aria-label="Choose an item"
+        className="bx--dropdown bx--list-box"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="listbox"
+        tabIndex="0"
+      >
+        <ListBoxField
+          aria-expanded={true}
+          aria-haspopup={true}
+          aria-label="close menu"
+          data-toggle={true}
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          type="button"
+        >
+          <div
+            aria-expanded={true}
+            aria-haspopup={true}
+            aria-label="close menu"
+            className="bx--list-box__field"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="0"
+            type="button"
+          >
+            <span
+              className="bx--list-box__label"
+              htmlFor="downshift-6-input"
+            >
+              input
+            </span>
+            <ListBoxMenuIcon
+              isOpen={true}
+              translateWithId={[Function]}
+            >
+              <div
+                className="bx--list-box__menu-icon bx--list-box__menu-icon--open"
+              >
+                <Icon
+                  alt="Close menu"
+                  description="Close menu"
+                  fillRule="evenodd"
+                  icon={
+                    Object {
+                      "height": "5",
+                      "id": "icon--caret--down",
+                      "name": "icon--caret--down",
+                      "styles": "",
+                      "svgData": Object {
+                        "circles": "",
+                        "ellipses": "",
+                        "paths": Array [
+                          Object {
+                            "d": "M0 0l5 4.998L10 0z",
+                          },
+                        ],
+                        "polygons": "",
+                        "polylines": "",
+                        "rects": "",
+                      },
+                      "tags": "icon--caret--down",
+                      "viewBox": "0 0 10 5",
+                      "width": "10",
+                    }
+                  }
+                  role="img"
+                >
+                  <svg
+                    alt="Close menu"
+                    aria-label="Close menu"
+                    fillRule="evenodd"
+                    height="5"
+                    role="img"
+                    viewBox="0 0 10 5"
+                    width="10"
+                  >
+                    <title>
+                      Close menu
+                    </title>
+                    <path
+                      d="M0 0l5 4.998L10 0z"
+                      key="key0"
+                    />
+                  </svg>
+                </Icon>
+              </div>
+            </ListBoxMenuIcon>
+          </div>
+        </ListBoxField>
+        <ListBoxMenu>
+          <div
+            className="bx--list-box__menu"
+          >
+            <ListBoxMenuItem
+              id="downshift-6-item-0"
+              isActive={false}
+              isHighlighted={false}
+              key="Item 0"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+            >
+              <div
+                className="bx--list-box__menu-item"
+                id="downshift-6-item-0"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+              >
+                <DropdownItem
+                  href=""
+                  id="id-0"
+                  key="Item 0"
+                  label="Item 0"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  selected={false}
+                  value={0}
+                >
+                  <li
+                    aria-selected={false}
+                    className="bx--dropdown-item"
+                    id="id-0"
+                    label="Item 0"
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="option"
+                    tabIndex={-1}
+                    value={0}
+                  >
+                    <a
+                      className="bx--dropdown-link"
+                      href=""
+                      onClick={[Function]}
+                      tabIndex={-1}
+                    />
+                  </li>
+                </DropdownItem>
+              </div>
+            </ListBoxMenuItem>
+            <ListBoxMenuItem
+              id="downshift-6-item-1"
+              isActive={false}
+              isHighlighted={false}
+              key="Item 1"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+            >
+              <div
+                className="bx--list-box__menu-item"
+                id="downshift-6-item-1"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+              >
+                <DropdownItem
+                  href=""
+                  id="id-1"
+                  key="Item 1"
+                  label="Item 1"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  selected={false}
+                  value={1}
+                >
+                  <li
+                    aria-selected={false}
+                    className="bx--dropdown-item"
+                    id="id-1"
+                    label="Item 1"
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="option"
+                    tabIndex={-1}
+                    value={1}
+                  >
+                    <a
+                      className="bx--dropdown-link"
+                      href=""
+                      onClick={[Function]}
+                      tabIndex={-1}
+                    />
+                  </li>
+                </DropdownItem>
+              </div>
+            </ListBoxMenuItem>
+            <ListBoxMenuItem
+              id="downshift-6-item-2"
+              isActive={false}
+              isHighlighted={false}
+              key="Item 2"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+            >
+              <div
+                className="bx--list-box__menu-item"
+                id="downshift-6-item-2"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+              >
+                <DropdownItem
+                  href=""
+                  id="id-2"
+                  key="Item 2"
+                  label="Item 2"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  selected={false}
+                  value={2}
+                >
+                  <li
+                    aria-selected={false}
+                    className="bx--dropdown-item"
+                    id="id-2"
+                    label="Item 2"
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="option"
+                    tabIndex={-1}
+                    value={2}
+                  >
+                    <a
+                      className="bx--dropdown-link"
+                      href=""
+                      onClick={[Function]}
+                      tabIndex={-1}
+                    />
+                  </li>
+                </DropdownItem>
+              </div>
+            </ListBoxMenuItem>
+            <ListBoxMenuItem
+              id="downshift-6-item-3"
+              isActive={false}
+              isHighlighted={false}
+              key="Item 3"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+            >
+              <div
+                className="bx--list-box__menu-item"
+                id="downshift-6-item-3"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+              >
+                <DropdownItem
+                  href=""
+                  id="id-3"
+                  key="Item 3"
+                  label="Item 3"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  selected={false}
+                  value={3}
+                >
+                  <li
+                    aria-selected={false}
+                    className="bx--dropdown-item"
+                    id="id-3"
+                    label="Item 3"
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="option"
+                    tabIndex={-1}
+                    value={3}
+                  >
+                    <a
+                      className="bx--dropdown-link"
+                      href=""
+                      onClick={[Function]}
+                      tabIndex={-1}
+                    />
+                  </li>
+                </DropdownItem>
+              </div>
+            </ListBoxMenuItem>
+            <ListBoxMenuItem
+              id="downshift-6-item-4"
+              isActive={false}
+              isHighlighted={false}
+              key="Item 4"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+            >
+              <div
+                className="bx--list-box__menu-item"
+                id="downshift-6-item-4"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+              >
+                <DropdownItem
+                  href=""
+                  id="id-4"
+                  key="Item 4"
+                  label="Item 4"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  selected={false}
+                  value={4}
+                >
+                  <li
+                    aria-selected={false}
+                    className="bx--dropdown-item"
+                    id="id-4"
+                    label="Item 4"
+                    onClick={[Function]}
+                    onKeyPress={[Function]}
+                    role="option"
+                    tabIndex={-1}
+                    value={4}
+                  >
+                    <a
+                      className="bx--dropdown-link"
+                      href=""
+                      onClick={[Function]}
+                      tabIndex={-1}
+                    />
+                  </li>
+                </DropdownItem>
+              </div>
+            </ListBoxMenuItem>
+          </div>
+        </ListBoxMenu>
+      </div>
+    </ListBox>
+  </Downshift>
+</DropdownV2>
+`;
+
+exports[`DropdownV2 should render custom item components 1`] = `
+<DropdownV2
+  disabled={false}
+  helperText=""
+  itemToElement={[Function]}
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "id": "id-0",
+        "label": "Item 0",
+        "value": 0,
+      },
+      Object {
+        "id": "id-1",
+        "label": "Item 1",
+        "value": 1,
+      },
+      Object {
+        "id": "id-2",
+        "label": "Item 2",
+        "value": 2,
+      },
+      Object {
+        "id": "id-3",
+        "label": "Item 3",
+        "value": 3,
+      },
+      Object {
+        "id": "id-4",
+        "label": "Item 4",
+        "value": 4,
+      },
+    ]
+  }
+  label="input"
+  light={false}
+  onChange={[MockFunction]}
+  placeholder="Filter..."
+  titleText=""
   type="default"
 >
   <Downshift
@@ -352,35 +768,18 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
               >
-                <DropdownItem
-                  href=""
+                <itemToElement
                   id="id-0"
                   key="Item 0"
                   label="Item 0"
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  selected={false}
                   value={0}
                 >
-                  <li
-                    aria-selected={false}
-                    className="bx--dropdown-item"
-                    id="id-0"
-                    label="Item 0"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    role="option"
-                    tabIndex={-1}
-                    value={0}
+                  <div
+                    className="mock-item"
                   >
-                    <a
-                      className="bx--dropdown-link"
-                      href=""
-                      onClick={[Function]}
-                      tabIndex={-1}
-                    />
-                  </li>
-                </DropdownItem>
+                    Item 0
+                  </div>
+                </itemToElement>
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
@@ -399,35 +798,18 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
               >
-                <DropdownItem
-                  href=""
+                <itemToElement
                   id="id-1"
                   key="Item 1"
                   label="Item 1"
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  selected={false}
                   value={1}
                 >
-                  <li
-                    aria-selected={false}
-                    className="bx--dropdown-item"
-                    id="id-1"
-                    label="Item 1"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    role="option"
-                    tabIndex={-1}
-                    value={1}
+                  <div
+                    className="mock-item"
                   >
-                    <a
-                      className="bx--dropdown-link"
-                      href=""
-                      onClick={[Function]}
-                      tabIndex={-1}
-                    />
-                  </li>
-                </DropdownItem>
+                    Item 1
+                  </div>
+                </itemToElement>
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
@@ -446,35 +828,18 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
               >
-                <DropdownItem
-                  href=""
+                <itemToElement
                   id="id-2"
                   key="Item 2"
                   label="Item 2"
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  selected={false}
                   value={2}
                 >
-                  <li
-                    aria-selected={false}
-                    className="bx--dropdown-item"
-                    id="id-2"
-                    label="Item 2"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    role="option"
-                    tabIndex={-1}
-                    value={2}
+                  <div
+                    className="mock-item"
                   >
-                    <a
-                      className="bx--dropdown-link"
-                      href=""
-                      onClick={[Function]}
-                      tabIndex={-1}
-                    />
-                  </li>
-                </DropdownItem>
+                    Item 2
+                  </div>
+                </itemToElement>
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
@@ -493,35 +858,18 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
               >
-                <DropdownItem
-                  href=""
+                <itemToElement
                   id="id-3"
                   key="Item 3"
                   label="Item 3"
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  selected={false}
                   value={3}
                 >
-                  <li
-                    aria-selected={false}
-                    className="bx--dropdown-item"
-                    id="id-3"
-                    label="Item 3"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    role="option"
-                    tabIndex={-1}
-                    value={3}
+                  <div
+                    className="mock-item"
                   >
-                    <a
-                      className="bx--dropdown-link"
-                      href=""
-                      onClick={[Function]}
-                      tabIndex={-1}
-                    />
-                  </li>
-                </DropdownItem>
+                    Item 3
+                  </div>
+                </itemToElement>
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
@@ -540,35 +888,18 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
               >
-                <DropdownItem
-                  href=""
+                <itemToElement
                   id="id-4"
                   key="Item 4"
                   label="Item 4"
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  selected={false}
                   value={4}
                 >
-                  <li
-                    aria-selected={false}
-                    className="bx--dropdown-item"
-                    id="id-4"
-                    label="Item 4"
-                    onClick={[Function]}
-                    onKeyPress={[Function]}
-                    role="option"
-                    tabIndex={-1}
-                    value={4}
+                  <div
+                    className="mock-item"
                   >
-                    <a
-                      className="bx--dropdown-link"
-                      href=""
-                      onClick={[Function]}
-                      tabIndex={-1}
-                    />
-                  </li>
-                </DropdownItem>
+                    Item 4
+                  </div>
+                </itemToElement>
               </div>
             </ListBoxMenuItem>
           </div>
@@ -579,44 +910,23 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
 </DropdownV2>
 `;
 
-exports[`DropdownV2 should render custom item components 1`] = `
+exports[`DropdownV2 should render with strings as items 1`] = `
 <DropdownV2
   disabled={false}
-  itemToElement={[Function]}
+  helperText=""
+  itemToElement={null}
   itemToString={[Function]}
   items={
     Array [
-      Object {
-        "id": "id-0",
-        "label": "Item 0",
-        "value": 0,
-      },
-      Object {
-        "id": "id-1",
-        "label": "Item 1",
-        "value": 1,
-      },
-      Object {
-        "id": "id-2",
-        "label": "Item 2",
-        "value": 2,
-      },
-      Object {
-        "id": "id-3",
-        "label": "Item 3",
-        "value": 3,
-      },
-      Object {
-        "id": "id-4",
-        "label": "Item 4",
-        "value": 4,
-      },
+      "zar",
+      "doz",
     ]
   }
   label="input"
   light={false}
   onChange={[MockFunction]}
   placeholder="Filter..."
+  titleText=""
   type="default"
 >
   <Downshift
@@ -750,7 +1060,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
               id="downshift-4-item-0"
               isActive={false}
               isHighlighted={false}
-              key="Item 0"
+              key="zar"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -762,313 +1072,11 @@ exports[`DropdownV2 should render custom item components 1`] = `
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
               >
-                <itemToElement
-                  id="id-0"
-                  key="Item 0"
-                  label="Item 0"
-                  value={0}
-                >
-                  <div
-                    className="mock-item"
-                  >
-                    Item 0
-                  </div>
-                </itemToElement>
-              </div>
-            </ListBoxMenuItem>
-            <ListBoxMenuItem
-              id="downshift-4-item-1"
-              isActive={false}
-              isHighlighted={false}
-              key="Item 1"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseMove={[Function]}
-            >
-              <div
-                className="bx--list-box__menu-item"
-                id="downshift-4-item-1"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseMove={[Function]}
-              >
-                <itemToElement
-                  id="id-1"
-                  key="Item 1"
-                  label="Item 1"
-                  value={1}
-                >
-                  <div
-                    className="mock-item"
-                  >
-                    Item 1
-                  </div>
-                </itemToElement>
-              </div>
-            </ListBoxMenuItem>
-            <ListBoxMenuItem
-              id="downshift-4-item-2"
-              isActive={false}
-              isHighlighted={false}
-              key="Item 2"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseMove={[Function]}
-            >
-              <div
-                className="bx--list-box__menu-item"
-                id="downshift-4-item-2"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseMove={[Function]}
-              >
-                <itemToElement
-                  id="id-2"
-                  key="Item 2"
-                  label="Item 2"
-                  value={2}
-                >
-                  <div
-                    className="mock-item"
-                  >
-                    Item 2
-                  </div>
-                </itemToElement>
-              </div>
-            </ListBoxMenuItem>
-            <ListBoxMenuItem
-              id="downshift-4-item-3"
-              isActive={false}
-              isHighlighted={false}
-              key="Item 3"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseMove={[Function]}
-            >
-              <div
-                className="bx--list-box__menu-item"
-                id="downshift-4-item-3"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseMove={[Function]}
-              >
-                <itemToElement
-                  id="id-3"
-                  key="Item 3"
-                  label="Item 3"
-                  value={3}
-                >
-                  <div
-                    className="mock-item"
-                  >
-                    Item 3
-                  </div>
-                </itemToElement>
-              </div>
-            </ListBoxMenuItem>
-            <ListBoxMenuItem
-              id="downshift-4-item-4"
-              isActive={false}
-              isHighlighted={false}
-              key="Item 4"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseMove={[Function]}
-            >
-              <div
-                className="bx--list-box__menu-item"
-                id="downshift-4-item-4"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseMove={[Function]}
-              >
-                <itemToElement
-                  id="id-4"
-                  key="Item 4"
-                  label="Item 4"
-                  value={4}
-                >
-                  <div
-                    className="mock-item"
-                  >
-                    Item 4
-                  </div>
-                </itemToElement>
-              </div>
-            </ListBoxMenuItem>
-          </div>
-        </ListBoxMenu>
-      </div>
-    </ListBox>
-  </Downshift>
-</DropdownV2>
-`;
-
-exports[`DropdownV2 should render with strings as items 1`] = `
-<DropdownV2
-  disabled={false}
-  itemToElement={null}
-  itemToString={[Function]}
-  items={
-    Array [
-      "zar",
-      "doz",
-    ]
-  }
-  label="input"
-  light={false}
-  onChange={[MockFunction]}
-  placeholder="Filter..."
-  type="default"
->
-  <Downshift
-    breakingChanges={Object {}}
-    defaultHighlightedIndex={null}
-    defaultInputValue=""
-    defaultIsOpen={false}
-    defaultSelectedItem={null}
-    environment={[Window]}
-    getA11yStatusMessage={[Function]}
-    itemToString={[Function]}
-    onChange={[Function]}
-    onInputValueChange={[Function]}
-    onOuterClick={[Function]}
-    onSelect={[Function]}
-    onStateChange={[Function]}
-    onUserAction={[Function]}
-    selectedItemChanged={[Function]}
-    stateReducer={[Function]}
-  >
-    <ListBox
-      ariaLabel="Choose an item"
-      className="bx--dropdown"
-      disabled={false}
-      innerRef={[Function]}
-      type="default"
-    >
-      <div
-        aria-label="Choose an item"
-        className="bx--dropdown bx--list-box"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        role="listbox"
-        tabIndex="0"
-      >
-        <ListBoxField
-          aria-expanded={true}
-          aria-haspopup={true}
-          aria-label="close menu"
-          data-toggle={true}
-          disabled={false}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="button"
-          type="button"
-        >
-          <div
-            aria-expanded={true}
-            aria-haspopup={true}
-            aria-label="close menu"
-            className="bx--list-box__field"
-            data-toggle={true}
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            role="button"
-            tabIndex="0"
-            type="button"
-          >
-            <span
-              className="bx--list-box__label"
-              htmlFor="downshift-3-input"
-            >
-              input
-            </span>
-            <ListBoxMenuIcon
-              isOpen={true}
-              translateWithId={[Function]}
-            >
-              <div
-                className="bx--list-box__menu-icon bx--list-box__menu-icon--open"
-              >
-                <Icon
-                  alt="Close menu"
-                  description="Close menu"
-                  fillRule="evenodd"
-                  icon={
-                    Object {
-                      "height": "5",
-                      "id": "icon--caret--down",
-                      "name": "icon--caret--down",
-                      "styles": "",
-                      "svgData": Object {
-                        "circles": "",
-                        "ellipses": "",
-                        "paths": Array [
-                          Object {
-                            "d": "M0 0l5 4.998L10 0z",
-                          },
-                        ],
-                        "polygons": "",
-                        "polylines": "",
-                        "rects": "",
-                      },
-                      "tags": "icon--caret--down",
-                      "viewBox": "0 0 10 5",
-                      "width": "10",
-                    }
-                  }
-                  role="img"
-                >
-                  <svg
-                    alt="Close menu"
-                    aria-label="Close menu"
-                    fillRule="evenodd"
-                    height="5"
-                    role="img"
-                    viewBox="0 0 10 5"
-                    width="10"
-                  >
-                    <title>
-                      Close menu
-                    </title>
-                    <path
-                      d="M0 0l5 4.998L10 0z"
-                      key="key0"
-                    />
-                  </svg>
-                </Icon>
-              </div>
-            </ListBoxMenuIcon>
-          </div>
-        </ListBoxField>
-        <ListBoxMenu>
-          <div
-            className="bx--list-box__menu"
-          >
-            <ListBoxMenuItem
-              id="downshift-3-item-0"
-              isActive={false}
-              isHighlighted={false}
-              key="zar"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseMove={[Function]}
-            >
-              <div
-                className="bx--list-box__menu-item"
-                id="downshift-3-item-0"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseMove={[Function]}
-              >
                 zar
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-3-item-1"
+              id="downshift-4-item-1"
               isActive={false}
               isHighlighted={false}
               key="doz"
@@ -1078,7 +1086,7 @@ exports[`DropdownV2 should render with strings as items 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-3-item-1"
+                id="downshift-4-item-1"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}


### PR DESCRIPTION
Closes IBM/carbon-components-react#1706

This PR adds optional props to `DropdownV2` for a title and helper text.

#### Changelog

**New**

- optional `titleText` and `helperText` props